### PR TITLE
fix: fix issue with user filtering by city in offline mode

### DIFF
--- a/lib/src/data/datasources/db/database_helper.dart
+++ b/lib/src/data/datasources/db/database_helper.dart
@@ -81,17 +81,27 @@ class DatabaseHelper {
     });
   }
 
-  Future<List<Map<String, dynamic>>> getCacheUsers(String category) async {
+  Future<List<Map<String, dynamic>>> getCacheUsers(String query) async {
     final db = await database;
     final List<Map<String, dynamic>> results = await db!.query(_tblCacheUser);
 
     return results;
   }
 
+  Future<List<Map<String, dynamic>>> getCacheFilteredUsers(String city) async {
+    final db = await database;
+    final List<Map<String, dynamic>> results = await db!.query(
+      _tblCacheUser,
+      where: 'city = ?',
+      whereArgs: [city],
+    );
+    print('...cache result: $results');
+    return results;
+  }
+
   Future<List<Map<String, dynamic>>> getCacheCities(String category) async {
     final db = await database;
     final List<Map<String, dynamic>> results = await db!.query(_tblCacheCity);
-
     return results;
   }
 

--- a/lib/src/data/datasources/user_local_data_source.dart
+++ b/lib/src/data/datasources/user_local_data_source.dart
@@ -9,6 +9,8 @@ abstract class UserLocalDataSource {
   Future<List<UserTable>> getCachedUsers();
 
   Future<List<UserTable>> searchLocalUsers(String query);
+
+  Future<List<UserTable>> filterLocalUsers(String query);
 }
 
 class UserLocalDataSourceImpl implements UserLocalDataSource {
@@ -24,7 +26,7 @@ class UserLocalDataSourceImpl implements UserLocalDataSource {
 
   @override
   Future<List<UserTable>> getCachedUsers() async {
-    final result = await databaseHelper.getCacheUsers('users');
+    final result = await databaseHelper.getCacheUsers("");
     if (result.isNotEmpty) {
       return result.map((data) => UserTable.fromMap(data)).toList();
     } else {
@@ -34,7 +36,7 @@ class UserLocalDataSourceImpl implements UserLocalDataSource {
 
   @override
   Future<List<UserTable>> searchLocalUsers(String query) async {
-    final result = await databaseHelper.getCacheUsers('users');
+    final result = await databaseHelper.getCacheUsers(query);
 
     if (result.isNotEmpty) {
       final filteredResults = result
@@ -45,9 +47,22 @@ class UserLocalDataSourceImpl implements UserLocalDataSource {
       if (filteredResults.isNotEmpty) {
         return filteredResults;
       } else {
-        throw CacheException("No users found with the specified criteria");
+        throw CacheException("No users found");
       }
     } else {
+      throw CacheException("Can't get the data");
+    }
+  }
+
+  @override
+  Future<List<UserTable>> filterLocalUsers(String query) async {
+    final result = await databaseHelper.getCacheFilteredUsers(query);
+
+    if (result.isNotEmpty) {
+      return result.map((data) => UserTable.fromMap(data)).toList();
+    } else if (result.isEmpty) {
+      throw CacheException("No user found");
+    } {
       throw CacheException("Can't get the data");
     }
   }

--- a/lib/src/data/repositories/user_repository_impl.dart
+++ b/lib/src/data/repositories/user_repository_impl.dart
@@ -61,7 +61,7 @@ class UserRepositoryImpl implements UserRepository {
       }
     } else {
       try {
-        final result = await localDataSource.getCachedUsers();
+        final result = await localDataSource.filterLocalUsers(city);
         return Right(result.map((model) => model.toEntity()).toList());
       } on CacheException catch (e) {
         return Left(CacheFailure(e.message));


### PR DESCRIPTION
fix: fix issue with user filtering by city in offline mode

Resolve a bug where filtering users by city was not functioning correctly when the application was offline. This fix ensures that users can still filter the user list by city even in offline mode. Key changes include:

- Implement local filtering logic to perform city-based filtering on cached user data.
- Update UI to reflect filtered results accurately when the device is offline.